### PR TITLE
Miscellaneous new features

### DIFF
--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -16,20 +16,12 @@ include("vaxfloatf.jl")
 include("vaxfloatd.jl")
 include("vaxfloatg.jl")
 include("promote.jl")
+include("math.jl")
 
 const VaxTypes = Union{VaxInt16,VaxInt32,VaxFloatF,VaxFloatD,VaxFloatG}
 
 function read(s::IO, ::Type{T}) where {T<:VaxTypes}
     return read!(s, Ref{T}(0))[]::T
-end
-
-# Define common arithmetic operations (default for two of the same unknown number type is to no-op error)
-# Promotion rules are such that the promotion will always be to a valid IEEE number type,
-# even in the case of two identical AbstractVax types
-for op in [:+, :-, :*, :/, :^, :<, :<=]
-    @eval(begin
-        Base.$op(x::T, y::T) where {T<:AbstractVax} = ($op)(promote(x,y)...)
-    end)
 end
 
 end # module

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -86,8 +86,9 @@ function Base.show(io::IO, x::VaxFloat)
     letter = (T === VaxFloatF) ? 'f' :
              (T === VaxFloatD) ? 'd' : 'g'
     print(io, "vax", letter)
+
     if T === VaxFloatF
-        show(io, strip(repr(convert(Float32, x); context=IOContext(io)), ['f', '0']))
+        show(io, replace(repr(convert(Float32, x); context=IOContext(io)), "f" => "e"))
     else
         show(io, repr(convert(Float64, x); context=IOContext(io)))
     end

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -6,9 +6,11 @@ abstract type AbstractVax <: Real end
 abstract type VaxInt <: AbstractVax end
 abstract type VaxFloat <: AbstractVax end
 
-import Base: IEEEFloat, convert, read, significand_bits, significand_mask, exponent_bits,
-    exponent_mask, exponent_bias, floatmin, floatmax, typemin, typemax, zero, one, uinttype
+import Base: IEEEFloat, convert, read, exponent, significand_bits, significand_mask,
+    exponent_bits, exponent_mask, exponent_bias, floatmin, floatmax, typemin, typemax,
+    nextfloat, prevfloat, zero, one, uinttype
 
+export VaxInt16, VaxInt32, VaxFloatF, VaxFloatD, VaxFloatG, @vaxf_str, @vaxd_str, @vaxg_str
 
 include("constants.jl")
 include("vaxints.jl")
@@ -19,6 +21,48 @@ include("promote.jl")
 include("math.jl")
 
 const VaxTypes = Union{VaxInt16,VaxInt32,VaxFloatF,VaxFloatD,VaxFloatG}
+
+function convert(::Type{T}, b::BigFloat) where {T<:VaxFloat}
+    sig = abs(significand(b))
+    U = uinttype(T)
+    m = zero(uinttype(T))
+    mbits = 0
+    while !iszero(sig) && mbits <= significand_bits(T)
+        setbit = Bool(sig >= 1)
+        sig -= setbit
+        m = U(m | setbit) << 1
+        sig *= 2
+        mbits += 1
+    end
+    e = ((exponent(b) + exponent_bias(T) + 1) % uinttype(T)) << (15 - exponent_bits(T))
+    if e > exponent_mask(T)
+        # overflow
+        throw(InexactError(:convert, T, b))
+    end
+    m <<= significand_bits(T) - mbits
+    if iszero(e)
+        # underflow
+        return zero(T)
+    end
+    m = swap16bword(m)
+    m &= significand_mask(T)
+    return T(e | (UInt32(signbit(b)) << 15) | m)
+end
+
+# dumb and probably not-at-all performant
+function convert(::Type{BigFloat}, v::T; precision=significand_bits(T)+1) where {T<:VaxFloat}
+    m = swap16bword(v.x)
+    bstr = bitstring(m)
+    s = signbit(v) ? "-" : ""
+    local sig
+    setprecision(precision) do
+        sig = parse(BigFloat,
+            string(s, "0.1", @view(bstr[end-significand_bits(T)+1:end]));
+            base=2)
+        sig *= big"2."^exponent(v)
+    end
+    return sig
+end
 
 function read(s::IO, ::Type{T}) where {T<:VaxTypes}
     return read!(s, Ref{T}(0))[]::T

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -73,13 +73,13 @@ export swap16bword
 @inline function swap16bword(x::Union{UInt32,Int32})
     part1 = x & typemax(UInt16)
     part2 = (x >>> 16) & typemax(UInt16)
-    part1 = (part1 << 16) | part2
+    return (part1 << 16) | part2
 end
 
 @inline function swap16bword(x::Union{UInt64,Int64})
     part1 = UInt64(swap16bword(UInt32(x & typemax(UInt32))))
     part2 = UInt64(swap16bword(UInt32((x >>> 32) & typemax(UInt32))))
-    part1 = (part2 << 32) | part1
+    return (part1 << 32) | part2
 end
 
 function Base.show(io::IO, x::VaxFloat)

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -6,8 +6,9 @@ abstract type AbstractVax <: Real end
 abstract type VaxInt <: AbstractVax end
 abstract type VaxFloat <: AbstractVax end
 
-import Base: IEEEFloat, significand_bits, significand_mask, exponent_bits, exponent_mask,
-    exponent_bias, floatmin, floatmax, typemin, typemax, zero, one, uinttype
+import Base: IEEEFloat, convert, read, significand_bits, significand_mask, exponent_bits,
+    exponent_mask, exponent_bias, floatmin, floatmax, typemin, typemax, zero, one, uinttype
+
 
 include("constants.jl")
 include("vaxints.jl")
@@ -18,7 +19,7 @@ include("promote.jl")
 
 const VaxTypes = Union{VaxInt16,VaxInt32,VaxFloatF,VaxFloatD,VaxFloatG}
 
-function Base.read(s::IO, ::Type{T}) where T <: VaxTypes
+function read(s::IO, ::Type{T}) where {T<:VaxTypes}
     return read!(s, Ref{T}(0))[]::T
 end
 

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -24,4 +24,17 @@ function read(s::IO, ::Type{T}) where {T<:VaxTypes}
     return read!(s, Ref{T}(0))[]::T
 end
 
+export swap16bword
+@inline function swap16bword(x::Union{UInt32,Int32})
+    part1 = x & typemax(UInt16)
+    part2 = (x >>> 16) & typemax(UInt16)
+    part1 = (part1 << 16) | part2
+end
+
+@inline function swap16bword(x::Union{UInt64,Int64})
+    part1 = UInt64(swap16bword(UInt32(x & typemax(UInt32))))
+    part2 = UInt64(swap16bword(UInt32((x >>> 32) & typemax(UInt32))))
+    part1 = (part2 << 32) | part1
+end
+
 end # module

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -52,6 +52,7 @@ end
 
 # dumb and probably not-at-all performant but works
 function convert(::Type{BigFloat}, v::T; precision=significand_bits(T)+1) where {T<:VaxFloat}
+    iszero(v) && return BigFloat(0; precision)
     m = swap16bword(v.x)
     bstr = bitstring(m)
     s = signbit(v) ? "-" : ""

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -28,19 +28,19 @@ function convert(::Type{T}, b::BigFloat) where {T<:VaxFloat}
     m = zero(uinttype(T))
     mbits = 0
     while !iszero(sig) && mbits <= significand_bits(T)
-        mbits += 1
         setbit = Bool(sig >= 1)
-        sig -= setbit
         m = U(m | setbit) << 1
+        sig -= setbit
         sig *= 2
+        mbits += 1
     end
     e = ((exponent(b) + exponent_bias(T) + 1) % uinttype(T)) << (15 - exponent_bits(T))
     if e > exponent_mask(T)
         # overflow
         throw(InexactError(:convert, T, b))
     end
-    m <<= significand_bits(T) - mbits
     0.5 ≤ sig < 1 && (m += one(m))
+    m >>>= -(significand_bits(T) - mbits) % Int
     if iszero(e)
         # underflow
         return zero(T)

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -22,24 +22,6 @@ function Base.read(s::IO, ::Type{T}) where T <: VaxTypes
     return read!(s, Ref{T}(0))[]::T
 end
 
-function Base.promote(x::T, y::T) where T <: AbstractVax
-    Base.@_inline_meta
-    px, py = Base._promote(x, y)
-    Base.not_sametype((x,y), (px,py))
-    px, py
-end
-function Base.promote(x::T, y::T, z::T) where T <: AbstractVax
-    Base.@_inline_meta
-    px, py, pz = Base._promote(x, y, z)
-    Base.not_sametype((x,y,z), (px,py,pz))
-    px, py, pz
-end
-function Base.promote(x::T, y::T, z::T, a::T...) where T <: AbstractVax
-    p = Base._promote(x, y, z, a...)
-    Base.not_sametype((x, y, z, a...), p)
-    p
-end
-
 # Define common arithmetic operations (default for two of the same unknown number type is to no-op error)
 # Promotion rules are such that the promotion will always be to a valid IEEE number type,
 # even in the case of two identical AbstractVax types

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -6,7 +6,8 @@ abstract type AbstractVax <: Real end
 abstract type VaxInt <: AbstractVax end
 abstract type VaxFloat <: AbstractVax end
 
-import Base: IEEEFloat
+import Base: IEEEFloat, significand_bits, significand_mask, exponent_bits, exponent_mask,
+    exponent_bias, floatmin, floatmax, typemin, typemax, zero, one, uinttype
 
 include("constants.jl")
 include("vaxints.jl")

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -81,4 +81,18 @@ end
     part1 = (part2 << 32) | part1
 end
 
+function Base.show(io::IO, x::VaxFloat)
+    T = typeof(x)
+    letter = (T === VaxFloatF) ? 'f' :
+             (T === VaxFloatD) ? 'd' : 'g'
+    print(io, "vax", letter)
+    if T === VaxFloatF
+        show(io, strip(repr(convert(Float32, x); context=IOContext(io)), ['f', '0']))
+    else
+        show(io, repr(convert(Float64, x); context=IOContext(io)))
+    end
+
+    return nothing
+end
+
 end # module

--- a/src/VaxData.jl
+++ b/src/VaxData.jl
@@ -89,10 +89,14 @@ function Base.show(io::IO, x::VaxFloat)
              (T === VaxFloatD) ? 'd' : 'g'
     print(io, "vax", letter)
 
-    if T === VaxFloatF
-        show(io, replace(repr(convert(Float32, x); context=IOContext(io)), "f" => "e"))
+    if get(io, :compact, false)
+        if T === VaxFloatF
+            show(io, replace(repr(convert(Float32, x); context=IOContext(io)), "f" => "e"))
+        else
+            show(io, repr(convert(Float64, x); context=IOContext(io)))
+        end
     else
-        show(io, repr(convert(Float64, x); context=IOContext(io)))
+        show(io, repr(convert(BigFloat, x)))
     end
 
     return nothing

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,0 +1,71 @@
+# Define common arithmetic operations (default for two of the same unknown number type is to no-op error)
+# Promotion rules are such that the promotion will always be to a valid IEEE number type,
+# even in the case of two identical AbstractVax types
+for op in [:+, :-, :*, :/, :^, :<=]
+    @eval(begin
+        Base.$op(x::T, y::T) where {T<:AbstractVax} = ($op)(promote(x,y)...)
+    end)
+end
+
+Base.signbit(x::VaxFloat) = !iszero(x.x & 0x8000)
+Base.:-(x::T) where {T<:VaxFloat} = T(x.x ⊻ 0x8000)
+
+function Base.:<(x::T,y::T) where {T<:VaxFloat}
+    if signbit(x) == signbit(y)
+        return (swap16bword(x.x) & (typemax(uinttype(T)) >> 1)) < (swap16bword(y.x) & (typemax(uinttype(T)) >> 1))
+    else
+        return signbit(x) > signbit(y)
+    end
+end
+
+# copied and slightly modified from Base
+function Base.nextfloat(f::VaxFloat, d::Integer)
+    F = typeof(f)
+    fumax = swap16bword(typemax(f).x)
+    U = typeof(fumax)
+
+    fi = signed(swap16bword(f.x))
+    fneg = fi < 0
+    fu = unsigned(fi & typemax(fi))
+
+    dneg = d < 0
+
+    da = Base.uabs(d)
+    if da > typemax(U)
+        fneg = dneg
+        fu = fumax
+    else
+        du = da % U
+        if fneg ⊻ dneg
+            if du > fu
+                fu = min(fumax, du - fu)
+                fneg = !fneg
+            else
+                fu = fu - du
+            end
+        else
+            if fumax - fu < du
+                fu = fumax
+            else
+                fu = fu + du
+            end
+        end
+    end
+    if fneg
+        fu |= SIGN_BIT
+    end
+
+    # Jump past the VAX FP reserved operand (sign = 1, exp = 0, mant ≠ 0)
+    dz_hi = ~(exponent_mask(F) % U)
+    dz_lo = dz_hi - significand_mask(F)
+    if dz_lo ≤ fu ≤ dz_hi
+        return dneg ? nextfloat(F(0x00008080), d + 1) :
+                      nextfloat(zero(F), d - 1)
+    end
+
+    return F(swap16bword(fu))
+end
+
+Base.nextfloat(f::VaxFloat) = nextfloat(f,1)
+Base.prevfloat(f::VaxFloat) = nextfloat(f,-1)
+Base.prevfloat(f::VaxFloat, d::Integer) = nextfloat(f, -d)

--- a/src/math.jl
+++ b/src/math.jl
@@ -69,7 +69,7 @@ function nextfloat(f::VaxFloat, d::Integer)
         end
     end
     if fneg
-        fu |= SIGN_BIT
+        fu |= one(U) << (sizeof(fu)*8 - 1)
     end
 
     # Jump past the VAX FP reserved operand (sign = 1, exp = 0, mant ≠ 0)

--- a/src/math.jl
+++ b/src/math.jl
@@ -19,7 +19,7 @@ function Base.:<(x::T,y::T) where {T<:VaxFloat}
 end
 
 # copied and slightly modified from Base
-function Base.nextfloat(f::VaxFloat, d::Integer)
+function nextfloat(f::VaxFloat, d::Integer)
     F = typeof(f)
     fumax = swap16bword(typemax(f).x)
     U = typeof(fumax)
@@ -56,8 +56,8 @@ function Base.nextfloat(f::VaxFloat, d::Integer)
     end
 
     # Jump past the VAX FP reserved operand (sign = 1, exp = 0, mant ≠ 0)
-    dz_hi = ~(exponent_mask(F) % U)
-    dz_lo = dz_hi - significand_mask(F)
+    dz_hi = ~(swap16bword(exponent_mask(F)) % U)
+    dz_lo = dz_hi - swap16bword(significand_mask(F))
     if dz_lo ≤ fu ≤ dz_hi
         return dneg ? nextfloat(F(0x00008080), d + 1) :
                       nextfloat(zero(F), d - 1)
@@ -66,6 +66,7 @@ function Base.nextfloat(f::VaxFloat, d::Integer)
     return F(swap16bword(fu))
 end
 
-Base.nextfloat(f::VaxFloat) = nextfloat(f,1)
-Base.prevfloat(f::VaxFloat) = nextfloat(f,-1)
-Base.prevfloat(f::VaxFloat, d::Integer) = nextfloat(f, -d)
+nextfloat(f::VaxFloat) = nextfloat(f,1)
+prevfloat(f::VaxFloat) = nextfloat(f,-1)
+prevfloat(f::VaxFloat, d::Integer) = nextfloat(f, -d)
+

--- a/src/promote.jl
+++ b/src/promote.jl
@@ -1,3 +1,21 @@
+function Base.promote(x::T, y::T) where T <: AbstractVax
+    Base.@_inline_meta
+    px, py = Base._promote(x, y)
+    Base.not_sametype((x,y), (px,py))
+    px, py
+end
+function Base.promote(x::T, y::T, z::T) where T <: AbstractVax
+    Base.@_inline_meta
+    px, py, pz = Base._promote(x, y, z)
+    Base.not_sametype((x,y,z), (px,py,pz))
+    px, py, pz
+end
+function Base.promote(x::T, y::T, z::T, a::T...) where T <: AbstractVax
+    p = Base._promote(x, y, z, a...)
+    Base.not_sametype((x, y, z, a...), p)
+    p
+end
+
 Base.promote_rule(::Type{VaxInt16}, ::Type{T}) where T <: Union{Int8,Int16} = Int16
 Base.promote_rule(::Type{VaxInt16}, ::Type{T}) where T <: Union{Int32,Int64,Int128} = T
 Base.promote_rule(::Type{VaxInt16}, ::Type{T}) where T <: IEEEFloat = T

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -133,6 +133,6 @@ uinttype(::Type{VaxFloatD}) = UInt64
 exponent_bits(::Type{VaxFloatD}) = VAX_D_EXPONENT_SIZE
 exponent_mask(::Type{VaxFloatD}) = UInt64(0x00007f80)
 exponent_bias(::Type{VaxFloatD}) = VAX_D_EXPONENT_BIAS
-significand_bits(::Type{VaxFloatD}) = VAX_D_MANTISSA_SIZE
+significand_bits(::Type{VaxFloatD}) = 64 - 1 - VAX_D_EXPONENT_SIZE
 significand_mask(::Type{VaxFloatD}) = 0xffffffffffff007f
 

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -30,10 +30,10 @@ function VaxFloatD(x::T) where {T<:Real}
         m = ieeepart1 & IEEE_T_MANTISSA_MASK
 
         if e === zero(Int64)
-            m = (m << 1) | (vaxpart2  >>> 31)
+            m = (m << 1) | (vaxpart2 >>> 31)
             vaxpart2 <<= 1
             while m & IEEE_T_HIDDEN_BIT === zero(UInt64)
-                m = (m << 1) | (vaxpart2  >>> 31)
+                m = (m << 1) | (vaxpart2 >>> 31)
                 vaxpart2 <<= 1
                 e -= one(Int64)
             end
@@ -44,14 +44,14 @@ function VaxFloatD(x::T) where {T<:Real}
         if e <= zero(Int64)
             # Silent underflow
             return zero(VaxFloatD)
-        elseif e > (2*VAX_D_EXPONENT_BIAS - 1)
+        elseif e > (2 * VAX_D_EXPONENT_BIAS - 1)
             # Overflow
             throw(InexactError(:VaxFloatD, VaxFloatD, x))
         else
             vaxpart = (ieeepart1 & SIGN_BIT_64) |
-                (e << VAX_D_MANTISSA_SIZE) |
-                (m <<  (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE)) |
-                (vaxpart2 >>> (32 - (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE)))
+                      (e << VAX_D_MANTISSA_SIZE) |
+                      (m << (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE)) |
+                      (vaxpart2 >>> (32 - (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE)))
             vaxpart2 <<= (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE)
         end
     end
@@ -63,9 +63,9 @@ function VaxFloatD(x::T) where {T<:Real}
     vaxpart_4 = (vaxpart2 >>> 16) & bmask16
 
     res = htol((vaxpart_3 << 48) |
-          (vaxpart_4 << 32) |
-          (vaxpart_1 << 16) |
-          vaxpart_2)
+               (vaxpart_4 << 32) |
+               (vaxpart_1 << 16) |
+               vaxpart_2)
 
     return VaxFloatD(res)
 end
@@ -93,7 +93,7 @@ function convert(::Type{Float64}, x::VaxFloatD)
         ieeepart1 = ((vaxpart1 & SIGN_BIT_64) |
                      ((vaxpart1 & ~SIGN_BIT_64) >>>
                       (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE))) -
-                     ((UNO64 + VAX_D_EXPONENT_BIAS - IEEE_T_EXPONENT_BIAS) << IEEE_T_MANTISSA_SIZE)
+                    ((UNO64 + VAX_D_EXPONENT_BIAS - IEEE_T_EXPONENT_BIAS) << IEEE_T_MANTISSA_SIZE)
         ieeepart2 = (vaxpart1 << (32 - (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE))) |
                     (vaxpart2 >>> (VAX_D_MANTISSA_SIZE - IEEE_T_MANTISSA_SIZE))
 
@@ -116,7 +116,7 @@ function convert(::Type{T}, x::VaxFloatD) where {T<:Union{Float16,Float32,BigFlo
 end
 
 floatmax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)
-floatmin(::Type{VaxFloatD}) = VaxFloatD(0x0000000000010000)
+floatmin(::Type{VaxFloatD}) = VaxFloatD(0x0000000000000080)
 typemax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)
 typemin(::Type{VaxFloatD}) = VaxFloatD(typemax(UInt64))
 

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -111,8 +111,13 @@ function convert(::Type{Float64}, x::VaxFloatD)
     return reinterpret(Float64, res)
 end
 
-function convert(::Type{T}, x::VaxFloatD) where {T<:Union{Float16,Float32,BigFloat,Integer}}
+function convert(::Type{T}, x::VaxFloatD) where {T<:Union{Float16,Float32,Integer}}
     return convert(T, convert(Float64, x))
+end
+
+macro vaxd_str(str)
+    T = VaxFloatD
+    return convert(T, BigFloat(str; precision=significand_bits(T)+1))
 end
 
 floatmax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -126,8 +126,8 @@ one(::Type{VaxFloatD}) = VaxFloatD(0x0000000000004080)
 uinttype(::Type{VaxFloatD}) = UInt64
 
 exponent_bits(::Type{VaxFloatD}) = VAX_D_EXPONENT_SIZE
-exponent_mask(::Type{VaxFloatD}) = VAX_D_EXPONENT_MASK
+exponent_mask(::Type{VaxFloatD}) = UInt64(0x00007f80)
 exponent_bias(::Type{VaxFloatD}) = VAX_D_EXPONENT_BIAS
 significand_bits(::Type{VaxFloatD}) = VAX_D_MANTISSA_SIZE
-significand_mask(::Type{VaxFloatD}) = VAX_D_MANTISSA_MASK
+significand_mask(::Type{VaxFloatD}) = 0xffffffffffff007f
 

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -72,14 +72,6 @@ function VaxFloatD(x::T) where T <: Real
     return VaxFloatD(res)
 end
 
-Base.typemax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)
-Base.floatmax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)
-Base.typemin(::Type{VaxFloatD}) = VaxFloatD(0x0000000000000080)
-Base.floatmin(::Type{VaxFloatD}) = VaxFloatD(0x0000000000000080)
-
-Base.zero(::Type{VaxFloatD}) = VaxFloatD(0x0000000000000000)
-Base.one(::Type{VaxFloatD}) = VaxFloatD(0x0000000000004080)
-
 function Base.convert(::Type{Float64}, x::VaxFloatD)
     y = ltoh(x.x)
 
@@ -124,4 +116,20 @@ end
 function Base.convert(::Type{T}, x::VaxFloatD) where T <: Union{Float16,Float32,BigFloat,Integer}
     return convert(T, convert(Float64, x))
 end
+
+floatmax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)
+floatmin(::Type{VaxFloatD}) = VaxFloatD(0x0000000000010000)
+typemax(::Type{VaxFloatD}) = VaxFloatD(0xffffffffffff7fff)
+typemin(::Type{VaxFloatD}) = VaxFloatD(typemax(UInt64))
+
+zero(::Type{VaxFloatD}) = VaxFloatD(0x0000000000000000)
+one(::Type{VaxFloatD}) = VaxFloatD(0x0000000000004080)
+
+uinttype(::Type{VaxFloatD}) = UInt64
+
+exponent_bits(::Type{VaxFloatD}) = VAX_D_EXPONENT_SIZE
+exponent_mask(::Type{VaxFloatD}) = VAX_D_EXPONENT_MASK
+exponent_bias(::Type{VaxFloatD}) = VAX_D_EXPONENT_BIAS
+significand_bits(::Type{VaxFloatD}) = VAX_D_MANTISSA_SIZE
+significand_mask(::Type{VaxFloatD}) = VAX_D_MANTISSA_MASK
 

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -1,12 +1,10 @@
-export VaxFloatD
-
 struct VaxFloatD <: VaxFloat
     x::UInt64
 
     VaxFloatD(x::UInt64) = new(ltoh(x))
 end
 
-function VaxFloatD(x::T) where T <: Real
+function VaxFloatD(x::T) where {T<:Real}
     y = reinterpret(UInt64, convert(Float64, x))
     part1 = y & bmask32
     part2 = (y >>> 32) & bmask32
@@ -72,7 +70,7 @@ function VaxFloatD(x::T) where T <: Real
     return VaxFloatD(res)
 end
 
-function Base.convert(::Type{Float64}, x::VaxFloatD)
+function convert(::Type{Float64}, x::VaxFloatD)
     y = ltoh(x.x)
 
     vaxpart_1 = y & bmask16
@@ -113,7 +111,7 @@ function Base.convert(::Type{Float64}, x::VaxFloatD)
     return reinterpret(Float64, res)
 end
 
-function Base.convert(::Type{T}, x::VaxFloatD) where T <: Union{Float16,Float32,BigFloat,Integer}
+function convert(::Type{T}, x::VaxFloatD) where {T<:Union{Float16,Float32,BigFloat,Integer}}
     return convert(T, convert(Float64, x))
 end
 

--- a/src/vaxfloatd.jl
+++ b/src/vaxfloatd.jl
@@ -1,7 +1,7 @@
 struct VaxFloatD <: VaxFloat
     x::UInt64
 
-    VaxFloatD(x::UInt64) = new(ltoh(x))
+    VaxFloatD(x::Union{UInt32,UInt64}) = new(UInt64(ltoh(x)))
 end
 
 function VaxFloatD(x::T) where {T<:Real}

--- a/src/vaxfloatf.jl
+++ b/src/vaxfloatf.jl
@@ -81,8 +81,13 @@ function convert(::Type{Float32}, x::VaxFloatF)
     return reinterpret(Float32, out)
 end
 
-function convert(::Type{T}, x::VaxFloatF) where {T<:Union{Float16,Float64,BigFloat,Integer}}
+function convert(::Type{T}, x::VaxFloatF) where {T<:Union{Float16,Float64,Integer}}
     return convert(T, convert(Float32, x))
+end
+
+macro vaxf_str(str)
+    T = VaxFloatF
+    return convert(T, BigFloat(str; precision=significand_bits(T)+1))
 end
 
 floatmax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)

--- a/src/vaxfloatf.jl
+++ b/src/vaxfloatf.jl
@@ -49,14 +49,6 @@ function VaxFloatF(x::T) where T <: Real
     return VaxFloatF(vaxpart1)
 end
 
-Base.typemax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)
-Base.floatmax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)
-Base.typemin(::Type{VaxFloatF}) = VaxFloatF(0x00000080)
-Base.floatmin(::Type{VaxFloatF}) = VaxFloatF(0x00000080)
-
-Base.zero(::Type{VaxFloatF}) = VaxFloatF(0x00000000)
-Base.one(::Type{VaxFloatF}) = VaxFloatF(0x00004080)
-
 function Base.convert(::Type{Float32}, x::VaxFloatF)
     y = x.x
     vaxpart1 = y & bmask16
@@ -94,4 +86,20 @@ end
 function Base.convert(::Type{T}, x::VaxFloatF) where T <: Union{Float16,Float64,BigFloat,Integer}
     return convert(T, convert(Float32, x))
 end
+
+floatmax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)
+floatmin(::Type{VaxFloatF}) = VaxFloatF(0x00010000)
+typemax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)
+typemin(::Type{VaxFloatF}) = VaxFloatF(typemax(UInt32))
+
+zero(::Type{VaxFloatF}) = VaxFloatF(0x00000000)
+one(::Type{VaxFloatF}) = VaxFloatF(0x00004080)
+
+uinttype(::Type{VaxFloatF}) = UInt32
+
+exponent_bits(::Type{VaxFloatF}) = VAX_F_EXPONENT_SIZE
+exponent_mask(::Type{VaxFloatF}) = VAX_F_EXPONENT_MASK
+exponent_bias(::Type{VaxFloatF}) = VAX_F_EXPONENT_BIAS
+significand_bits(::Type{VaxFloatF}) = VAX_F_MANTISSA_SIZE
+significand_mask(::Type{VaxFloatF}) = VAX_F_MANTISSA_MASK
 

--- a/src/vaxfloatf.jl
+++ b/src/vaxfloatf.jl
@@ -1,12 +1,10 @@
-export VaxFloatF
-
 struct VaxFloatF <: VaxFloat
     x::UInt32
 
     VaxFloatF(x::UInt32) = new(ltoh(x))
 end
 
-function VaxFloatF(x::T) where T <: Real
+function VaxFloatF(x::T) where {T<:Real}
     ieeepart1 = reinterpret(UInt32, convert(Float32, x))
     e = reinterpret(Int32, ieeepart1 & IEEE_S_EXPONENT_MASK)
 
@@ -49,7 +47,7 @@ function VaxFloatF(x::T) where T <: Real
     return VaxFloatF(vaxpart1)
 end
 
-function Base.convert(::Type{Float32}, x::VaxFloatF)
+function convert(::Type{Float32}, x::VaxFloatF)
     y = x.x
     vaxpart1 = y & bmask16
     vaxpart2 = (y >>> 16) & bmask16
@@ -83,7 +81,7 @@ function Base.convert(::Type{Float32}, x::VaxFloatF)
     return reinterpret(Float32, out)
 end
 
-function Base.convert(::Type{T}, x::VaxFloatF) where T <: Union{Float16,Float64,BigFloat,Integer}
+function convert(::Type{T}, x::VaxFloatF) where {T<:Union{Float16,Float64,BigFloat,Integer}}
     return convert(T, convert(Float32, x))
 end
 

--- a/src/vaxfloatf.jl
+++ b/src/vaxfloatf.jl
@@ -96,8 +96,8 @@ one(::Type{VaxFloatF}) = VaxFloatF(0x00004080)
 uinttype(::Type{VaxFloatF}) = UInt32
 
 exponent_bits(::Type{VaxFloatF}) = VAX_F_EXPONENT_SIZE
-exponent_mask(::Type{VaxFloatF}) = VAX_F_EXPONENT_MASK
+exponent_mask(::Type{VaxFloatF}) = 0x00007f80
 exponent_bias(::Type{VaxFloatF}) = VAX_F_EXPONENT_BIAS
 significand_bits(::Type{VaxFloatF}) = VAX_F_MANTISSA_SIZE
-significand_mask(::Type{VaxFloatF}) = VAX_F_MANTISSA_MASK
+significand_mask(::Type{VaxFloatF}) = 0xffff007f
 

--- a/src/vaxfloatf.jl
+++ b/src/vaxfloatf.jl
@@ -31,7 +31,7 @@ function VaxFloatF(x::T) where {T<:Real}
         if e <= 0
             # Silent underflow
             return zero(VaxFloatF)
-        elseif e > (2*VAX_F_EXPONENT_BIAS - 1)
+        elseif e > (2 * VAX_F_EXPONENT_BIAS - 1)
             # Overflow
             throw(InexactError(:VaxFloatF, VaxFloatF, x))
         else
@@ -56,7 +56,7 @@ function convert(::Type{Float32}, x::VaxFloatF)
     e = reinterpret(Int32, vaxpart1 & VAX_F_EXPONENT_MASK)
 
     if e === zero(Int32)
-        if vaxpart1 & SIGN_BIT === SIGN_BIT
+        if (vaxpart1 & SIGN_BIT) === SIGN_BIT
             # Reserved floating-point reserved operand
             throw(InexactError(:convert, Float32, x))
         end
@@ -69,12 +69,12 @@ function convert(::Type{Float32}, x::VaxFloatF)
         e -= one(Int32) + VAX_F_EXPONENT_BIAS - IEEE_S_EXPONENT_BIAS
         if e > zero(Int32)
             out = vaxpart1 -
-                (( UNO + VAX_F_EXPONENT_BIAS - IEEE_S_EXPONENT_BIAS ) <<
-                    IEEE_S_MANTISSA_SIZE)
+                  ((UNO + VAX_F_EXPONENT_BIAS - IEEE_S_EXPONENT_BIAS) <<
+                   IEEE_S_MANTISSA_SIZE)
         else
             # out will be a subnormal
             out = (vaxpart1 & SIGN_BIT) |
-                ((VAX_F_HIDDEN_BIT | (vaxpart1 & VAX_F_MANTISSA_MASK)) >>> (UNO - e))
+                  ((VAX_F_HIDDEN_BIT | (vaxpart1 & VAX_F_MANTISSA_MASK)) >>> (UNO - e))
         end
     end
 
@@ -86,7 +86,7 @@ function convert(::Type{T}, x::VaxFloatF) where {T<:Union{Float16,Float64,BigFlo
 end
 
 floatmax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)
-floatmin(::Type{VaxFloatF}) = VaxFloatF(0x00010000)
+floatmin(::Type{VaxFloatF}) = VaxFloatF(0x00000080)
 typemax(::Type{VaxFloatF}) = VaxFloatF(0xffff7fff)
 typemin(::Type{VaxFloatF}) = VaxFloatF(typemax(UInt32))
 

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -137,6 +137,6 @@ uinttype(::Type{VaxFloatG}) = UInt64
 exponent_bits(::Type{VaxFloatG}) = VAX_G_EXPONENT_SIZE
 exponent_mask(::Type{VaxFloatG}) = UInt64(0x00007ff0)
 exponent_bias(::Type{VaxFloatG}) = VAX_G_EXPONENT_BIAS
-significand_bits(::Type{VaxFloatG}) = VAX_G_MANTISSA_SIZE
+significand_bits(::Type{VaxFloatG}) = 64 - 1 - VAX_G_EXPONENT_SIZE
 significand_mask(::Type{VaxFloatG}) = 0xffffffffffff001f
 

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -115,8 +115,13 @@ function convert(::Type{Float64}, x::VaxFloatG)
     return reinterpret(Float64, res)
 end
 
-function convert(::Type{T}, x::VaxFloatG) where {T<:Union{Float16,Float32,BigFloat,Integer}}
+function convert(::Type{T}, x::VaxFloatG) where {T<:Union{Float16,Float32,Integer}}
     return convert(T, convert(Float64, x))
+end
+
+macro vaxg_str(str)
+    T = VaxFloatG
+    return convert(T, BigFloat(str; precision=significand_bits(T)+1))
 end
 
 floatmax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -1,12 +1,10 @@
-export VaxFloatG
-
 struct VaxFloatG <: VaxFloat
     x::UInt64
 
     VaxFloatG(x::UInt64) = new(ltoh(x))
 end
 
-function VaxFloatG(x::T) where T <: Real
+function VaxFloatG(x::T) where {T<:Real}
     y = reinterpret(UInt64, convert(Float64, x))
 
     part1 = y & bmask32
@@ -62,14 +60,14 @@ function VaxFloatG(x::T) where T <: Real
     vaxpart_4 = (vaxpart2 >>> 16) & bmask16
 
     res = htol((vaxpart_3 << 48) |
-          (vaxpart_4 << 32) |
-          (vaxpart_1 << 16) |
-          vaxpart_2)
+               (vaxpart_4 << 32) |
+               (vaxpart_1 << 16) |
+               vaxpart_2)
 
     return VaxFloatG(res)
 end
 
-function Base.convert(::Type{Float64}, x::VaxFloatG)
+function convert(::Type{Float64}, x::VaxFloatG)
     y = ltoh(x.x)
 
     vaxpart_1 = y & bmask16
@@ -117,7 +115,7 @@ function Base.convert(::Type{Float64}, x::VaxFloatG)
     return reinterpret(Float64, res)
 end
 
-function Base.convert(::Type{T}, x::VaxFloatG) where T <: Union{Float16,Float32,BigFloat,Integer}
+function convert(::Type{T}, x::VaxFloatG) where {T<:Union{Float16,Float32,BigFloat,Integer}}
     return convert(T, convert(Float64, x))
 end
 

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -1,7 +1,7 @@
 struct VaxFloatG <: VaxFloat
     x::UInt64
 
-    VaxFloatG(x::UInt64) = new(ltoh(x))
+    VaxFloatG(x::Union{UInt32,UInt64}) = new(UInt64(ltoh(x)))
 end
 
 function VaxFloatG(x::T) where {T<:Real}

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -138,5 +138,5 @@ exponent_bits(::Type{VaxFloatG}) = VAX_G_EXPONENT_SIZE
 exponent_mask(::Type{VaxFloatG}) = UInt64(0x00007ff0)
 exponent_bias(::Type{VaxFloatG}) = VAX_G_EXPONENT_BIAS
 significand_bits(::Type{VaxFloatG}) = 64 - 1 - VAX_G_EXPONENT_SIZE
-significand_mask(::Type{VaxFloatG}) = 0xffffffffffff001f
+significand_mask(::Type{VaxFloatG}) = 0xffffffffffff000f
 

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -45,7 +45,7 @@ function VaxFloatG(x::T) where {T<:Real}
         if e <= zero(Int64)
             # Silent underflow
             return zero(VaxFloatG)
-        elseif e > (2*VAX_G_EXPONENT_BIAS - 1)
+        elseif e > (2 * VAX_G_EXPONENT_BIAS - 1)
             # Overflow
             throw(InexactError(:VaxFloatG, VaxFloatG, x))
         else
@@ -92,7 +92,7 @@ function convert(::Type{Float64}, x::VaxFloatG)
 
         e -= one(Int64) + VAX_G_EXPONENT_BIAS - IEEE_T_EXPONENT_BIAS
         if e > zero(Int64)
-            ieeepart1 = vaxpart1  - ((UNO64 + VAX_G_EXPONENT_BIAS - IEEE_T_EXPONENT_BIAS) << IEEE_T_MANTISSA_SIZE)
+            ieeepart1 = vaxpart1 - ((UNO64 + VAX_G_EXPONENT_BIAS - IEEE_T_EXPONENT_BIAS) << IEEE_T_MANTISSA_SIZE)
             ieeepart2 = vaxpart2
         else
             # Subnormal result
@@ -120,7 +120,7 @@ function convert(::Type{T}, x::VaxFloatG) where {T<:Union{Float16,Float32,BigFlo
 end
 
 floatmax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)
-floatmin(::Type{VaxFloatG}) = VaxFloatG(0x0000000000010000)
+floatmin(::Type{VaxFloatG}) = VaxFloatG(0x0000000000000010)
 typemax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)
 typemin(::Type{VaxFloatG}) = VaxFloatG(typemax(UInt64))
 

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -69,14 +69,6 @@ function VaxFloatG(x::T) where T <: Real
     return VaxFloatG(res)
 end
 
-Base.typemax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)
-Base.floatmax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)
-Base.floatmin(::Type{VaxFloatG}) = VaxFloatG(0x0000000000000010)
-Base.typemin(::Type{VaxFloatG}) = VaxFloatG(0x0000000000000010)
-
-Base.zero(::Type{VaxFloatG}) = VaxFloatG(0x0000000000000000)
-Base.one(::Type{VaxFloatG}) = VaxFloatG(0x0000000000004010)
-
 function Base.convert(::Type{Float64}, x::VaxFloatG)
     y = ltoh(x.x)
 
@@ -128,4 +120,20 @@ end
 function Base.convert(::Type{T}, x::VaxFloatG) where T <: Union{Float16,Float32,BigFloat,Integer}
     return convert(T, convert(Float64, x))
 end
+
+floatmax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)
+floatmin(::Type{VaxFloatG}) = VaxFloatG(0x0000000000010000)
+typemax(::Type{VaxFloatG}) = VaxFloatG(0xffffffffffff7fff)
+typemin(::Type{VaxFloatG}) = VaxFloatG(typemax(UInt64))
+
+zero(::Type{VaxFloatG}) = VaxFloatG(0x0000000000000000)
+one(::Type{VaxFloatG}) = VaxFloatG(0x0000000000004010)
+
+uinttype(::Type{VaxFloatG}) = UInt64
+
+exponent_bits(::Type{VaxFloatG}) = VAX_G_EXPONENT_SIZE
+exponent_mask(::Type{VaxFloatG}) = VAX_G_EXPONENT_MASK
+exponent_bias(::Type{VaxFloatG}) = VAX_G_EXPONENT_BIAS
+significand_bits(::Type{VaxFloatG}) = VAX_G_MANTISSA_SIZE
+significand_mask(::Type{VaxFloatG}) = VAX_G_MANTISSA_MASK
 

--- a/src/vaxfloatg.jl
+++ b/src/vaxfloatg.jl
@@ -130,8 +130,8 @@ one(::Type{VaxFloatG}) = VaxFloatG(0x0000000000004010)
 uinttype(::Type{VaxFloatG}) = UInt64
 
 exponent_bits(::Type{VaxFloatG}) = VAX_G_EXPONENT_SIZE
-exponent_mask(::Type{VaxFloatG}) = VAX_G_EXPONENT_MASK
+exponent_mask(::Type{VaxFloatG}) = UInt64(0x00007ff0)
 exponent_bias(::Type{VaxFloatG}) = VAX_G_EXPONENT_BIAS
 significand_bits(::Type{VaxFloatG}) = VAX_G_MANTISSA_SIZE
-significand_mask(::Type{VaxFloatG}) = VAX_G_MANTISSA_MASK
+significand_mask(::Type{VaxFloatG}) = 0xffffffffffff001f
 

--- a/src/vaxints.jl
+++ b/src/vaxints.jl
@@ -1,5 +1,3 @@
-export VaxInt16, VaxInt32
-
 struct VaxInt16 <: VaxInt
     x::UInt16
 

--- a/test/vaxfloatd.jl
+++ b/test/vaxfloatd.jl
@@ -46,7 +46,7 @@
 
     @testset "Number definitions" begin
         @test floatmax(VaxFloatD) == typemax(VaxFloatD)
-        @test floatmin(VaxFloatD) == typemin(VaxFloatD)
+        @test_broken floatmin(VaxFloatD) == typemin(VaxFloatD)
 
         @test zero(VaxFloatD) == 0
         @test one(VaxFloatD) == 1
@@ -69,7 +69,7 @@
 
         # Numbers smaller than floatmin(VaxFloatD) should underflow
         @test VaxFloatD(prevfloat(convert(Float64, floatmin(VaxFloatD)))) === zero(VaxFloatD)
-        @test VaxFloatD(convert(Float64, floatmin(VaxFloatD))) === floatmin(VaxFloatD)
+        @test_broken VaxFloatD(convert(Float64, floatmin(VaxFloatD))) === floatmin(VaxFloatD)
 
         # Numbers larger than floatmax(VaxFloatD) should error
         @test_throws InexactError VaxFloatD(nextfloat(convert(Float64, floatmax(VaxFloatD))))

--- a/test/vaxfloatd.jl
+++ b/test/vaxfloatd.jl
@@ -66,7 +66,7 @@
 
     @testset "Number definitions" begin
         @test floatmax(VaxFloatD) == typemax(VaxFloatD)
-        @test_broken floatmin(VaxFloatD) == typemin(VaxFloatD)
+        @test -typemax(VaxFloatD) == typemin(VaxFloatD)
 
         @test zero(VaxFloatD) == 0
         @test one(VaxFloatD) == 1
@@ -89,7 +89,7 @@
 
         # Numbers smaller than floatmin(VaxFloatD) should underflow
         @test VaxFloatD(prevfloat(convert(Float64, floatmin(VaxFloatD)))) === zero(VaxFloatD)
-        @test_broken VaxFloatD(convert(Float64, floatmin(VaxFloatD))) === floatmin(VaxFloatD)
+        @test VaxFloatD(convert(Float64, floatmin(VaxFloatD))) === floatmin(VaxFloatD)
 
         # Numbers larger than floatmax(VaxFloatD) should error
         @test_throws InexactError VaxFloatD(nextfloat(convert(Float64, floatmax(VaxFloatD))))

--- a/test/vaxfloatd.jl
+++ b/test/vaxfloatd.jl
@@ -50,6 +50,13 @@
             @test VaxFloatD(vax) == VaxFloatD(ieee)
             @test convert(Float64, VaxFloatD(vax)) == ieee
         end
+
+        @test convert(VaxFloatD, big"1.0") == one(VaxFloatD)
+        @test convert(VaxFloatD, big"-1.0") == -one(VaxFloatD)
+        bigpi = BigFloat(π; precision=Base.significand_bits(VaxFloatD)+1)
+        bige = BigFloat(ℯ; precision=Base.significand_bits(VaxFloatD)+1)
+        @test convert(BigFloat, convert(VaxFloatD, bigpi)) == bigpi
+        @test convert(BigFloat, convert(VaxFloatD, bige)) == bige
     end
 
     @testset "Promotion..." begin

--- a/test/vaxfloatd.jl
+++ b/test/vaxfloatd.jl
@@ -25,6 +25,26 @@
                                 1.2345678901234500000000000000,
                                 -1.2345678901234500000000000000 ])
 
+    @testset "Basic operators" begin
+        @test signbit(zero(VaxFloatD)) == false
+        @test signbit(one(VaxFloatD)) == false
+        @test signbit(-one(VaxFloatD)) == true
+        @test signbit(-(-one(VaxFloatD))) == false
+
+        @test zero(VaxFloatD) < one(VaxFloatD)
+        @test !(one(VaxFloatD) < one(VaxFloatD))
+        @test !(one(VaxFloatD) < zero(VaxFloatD))
+        @test one(VaxFloatD) <= one(VaxFloatD)
+
+        @test nextfloat(typemax(VaxFloatD)) == typemax(VaxFloatD)
+        @test prevfloat(typemin(VaxFloatD)) == typemin(VaxFloatD)
+        @test -prevfloat(-one(VaxFloatD)) == nextfloat(one(VaxFloatD))
+        @test nextfloat(zero(VaxFloatD)) == floatmin(VaxFloatD)
+        @test prevfloat(floatmin(VaxFloatD)) == zero(VaxFloatD)
+        @test prevfloat(zero(VaxFloatD)) == -floatmin(VaxFloatD)
+        @test nextfloat(-floatmin(VaxFloatD)) == zero(VaxFloatD)
+    end
+
     @testset "Conversion..." begin
         for (vax, ieee) in zip(d8_vax, d8_ieee)
             @test VaxFloatD(vax) == VaxFloatD(ieee)

--- a/test/vaxfloatf.jl
+++ b/test/vaxfloatf.jl
@@ -50,6 +50,13 @@
             @test VaxFloatF(vax) == VaxFloatF(ieee)
             @test convert(Float32, VaxFloatF(vax)) == ieee
         end
+
+        @test convert(VaxFloatF, big"1.0") == one(VaxFloatF)
+        @test convert(VaxFloatF, big"-1.0") == -one(VaxFloatF)
+        bigpi = BigFloat(π; precision=Base.significand_bits(VaxFloatF)+1)
+        bige = BigFloat(ℯ; precision=Base.significand_bits(VaxFloatF)+1)
+        @test convert(BigFloat, convert(VaxFloatF, bigpi)) == bigpi
+        @test convert(BigFloat, convert(VaxFloatF, bige)) == bige
     end
 
     @testset "Promotion..." begin

--- a/test/vaxfloatf.jl
+++ b/test/vaxfloatf.jl
@@ -48,7 +48,7 @@
 
     @testset "Number definitions" begin
         @test floatmax(VaxFloatF) == typemax(VaxFloatF)
-        @test floatmin(VaxFloatF) == typemin(VaxFloatF)
+        @test_broken floatmin(VaxFloatF) == typemin(VaxFloatF)
 
         @test zero(VaxFloatF) == 0
         @test one(VaxFloatF) == 1
@@ -71,7 +71,7 @@
 
         # Numbers smaller than floatmin(VaxFloatF) should underflow
         @test VaxFloatF(prevfloat(convert(Float32, floatmin(VaxFloatF)))) === zero(VaxFloatF)
-        @test VaxFloatF(convert(Float32, floatmin(VaxFloatF))) === floatmin(VaxFloatF)
+        @test_broken VaxFloatF(convert(Float32, floatmin(VaxFloatF))) === floatmin(VaxFloatF)
 
         # Numbers larger than floatmax(VaxFloatF) should error
         @test_throws InexactError VaxFloatF(nextfloat(convert(Float32, floatmax(VaxFloatF))))

--- a/test/vaxfloatf.jl
+++ b/test/vaxfloatf.jl
@@ -68,7 +68,7 @@
 
     @testset "Number definitions" begin
         @test floatmax(VaxFloatF) == typemax(VaxFloatF)
-        @test_broken floatmin(VaxFloatF) == typemin(VaxFloatF)
+        @test -typemax(VaxFloatF) == typemin(VaxFloatF)
 
         @test zero(VaxFloatF) == 0
         @test one(VaxFloatF) == 1
@@ -91,7 +91,7 @@
 
         # Numbers smaller than floatmin(VaxFloatF) should underflow
         @test VaxFloatF(prevfloat(convert(Float32, floatmin(VaxFloatF)))) === zero(VaxFloatF)
-        @test_broken VaxFloatF(convert(Float32, floatmin(VaxFloatF))) === floatmin(VaxFloatF)
+        @test VaxFloatF(convert(Float32, floatmin(VaxFloatF))) === floatmin(VaxFloatF)
 
         # Numbers larger than floatmax(VaxFloatF) should error
         @test_throws InexactError VaxFloatF(nextfloat(convert(Float32, floatmax(VaxFloatF))))

--- a/test/vaxfloatf.jl
+++ b/test/vaxfloatf.jl
@@ -25,6 +25,26 @@
                                 1.23456789,
                                -1.23456789 ])
 
+    @testset "Basic operators" begin
+        @test signbit(zero(VaxFloatF)) == false
+        @test signbit(one(VaxFloatF)) == false
+        @test signbit(-one(VaxFloatF)) == true
+        @test signbit(-(-one(VaxFloatF))) == false
+
+        @test zero(VaxFloatF) < one(VaxFloatF)
+        @test !(one(VaxFloatF) < one(VaxFloatF))
+        @test !(one(VaxFloatF) < zero(VaxFloatF))
+        @test one(VaxFloatF) <= one(VaxFloatF)
+
+        @test nextfloat(typemax(VaxFloatF)) == typemax(VaxFloatF)
+        @test prevfloat(typemin(VaxFloatF)) == typemin(VaxFloatF)
+        @test -prevfloat(-one(VaxFloatF)) == nextfloat(one(VaxFloatF))
+        @test nextfloat(zero(VaxFloatF)) == floatmin(VaxFloatF)
+        @test prevfloat(floatmin(VaxFloatF)) == zero(VaxFloatF)
+        @test prevfloat(zero(VaxFloatF)) == -floatmin(VaxFloatF)
+        @test nextfloat(-floatmin(VaxFloatF)) == zero(VaxFloatF)
+    end
+
     @testset "Conversion..." begin
         for (vax, ieee) in zip(f4_vax, f4_ieee)
             @test VaxFloatF(vax) == VaxFloatF(ieee)

--- a/test/vaxfloatf_completecov.jl
+++ b/test/vaxfloatf_completecov.jl
@@ -1,0 +1,17 @@
+function isvalid_bitpattern(::Type{T}, x::UInt32) where {T<:VaxFloat}
+    (~Base.exponent_mask(T) ⊻ (x | Base.exponent_mask(T))) === typemax(x)
+end
+
+inexacts = [ UInt32[] for _ in 1:Threads.nthreads() ]
+
+Threads.@threads for i in typemin(UInt32):typemax(UInt32)
+    !isvalid_bitpattern(VaxFloatF, i) && continue
+    if convert(VaxFloatF, convert(BigFloat, VaxFloatF(i))) !== VaxFloatF(i)
+        push!(inexacts[Threads.threadid()], i)
+    end
+end
+
+allinexact = reduce(vcat, inexacts)
+
+@test isempty(allinexact)
+

--- a/test/vaxfloatg.jl
+++ b/test/vaxfloatg.jl
@@ -66,7 +66,7 @@
 
     @testset "Number definitions" begin
         @test floatmax(VaxFloatG) == typemax(VaxFloatG)
-        @test_broken floatmin(VaxFloatG) == typemin(VaxFloatG)
+        @test -typemax(VaxFloatG) == typemin(VaxFloatG)
 
         @test zero(VaxFloatG) == 0
         @test one(VaxFloatG) == 1
@@ -89,7 +89,7 @@
 
         # Numbers smaller than floatmin(VaxFloatG) should underflow
         @test VaxFloatG(prevfloat(convert(Float64, floatmin(VaxFloatG)))) === zero(VaxFloatG)
-        @test_broken VaxFloatG(convert(Float64, floatmin(VaxFloatG))) === floatmin(VaxFloatG)
+        @test VaxFloatG(convert(Float64, floatmin(VaxFloatG))) === floatmin(VaxFloatG)
 
         # Numbers larger than floatmax(VaxFloatG) should error
         @test_throws InexactError VaxFloatG(nextfloat(convert(Float64, floatmax(VaxFloatG))))

--- a/test/vaxfloatg.jl
+++ b/test/vaxfloatg.jl
@@ -50,6 +50,13 @@
             @test VaxFloatG(vax) == VaxFloatG(ieee)
             @test convert(Float64, VaxFloatG(vax)) == ieee
         end
+
+        @test convert(VaxFloatG, big"1.0") == one(VaxFloatG)
+        @test convert(VaxFloatG, big"-1.0") == -one(VaxFloatG)
+        bigpi = BigFloat(π; precision=Base.significand_bits(VaxFloatG)+1)
+        bige = BigFloat(ℯ; precision=Base.significand_bits(VaxFloatG)+1)
+        @test convert(BigFloat, convert(VaxFloatG, bigpi)) == bigpi
+        @test convert(BigFloat, convert(VaxFloatG, bige)) == bige
     end
 
     @testset "Promotion..." begin

--- a/test/vaxfloatg.jl
+++ b/test/vaxfloatg.jl
@@ -25,6 +25,26 @@
                                 1.2345678901234500000000000000,
                                 -1.2345678901234500000000000000 ])
 
+    @testset "Basic operators" begin
+        @test signbit(zero(VaxFloatG)) == false
+        @test signbit(one(VaxFloatG)) == false
+        @test signbit(-one(VaxFloatG)) == true
+        @test signbit(-(-one(VaxFloatG))) == false
+
+        @test zero(VaxFloatG) < one(VaxFloatG)
+        @test !(one(VaxFloatG) < one(VaxFloatG))
+        @test !(one(VaxFloatG) < zero(VaxFloatG))
+        @test one(VaxFloatG) <= one(VaxFloatG)
+
+        @test nextfloat(typemax(VaxFloatG)) == typemax(VaxFloatG)
+        @test prevfloat(typemin(VaxFloatG)) == typemin(VaxFloatG)
+        @test -prevfloat(-one(VaxFloatG)) == nextfloat(one(VaxFloatG))
+        @test nextfloat(zero(VaxFloatG)) == floatmin(VaxFloatG)
+        @test prevfloat(floatmin(VaxFloatG)) == zero(VaxFloatG)
+        @test prevfloat(zero(VaxFloatG)) == -floatmin(VaxFloatG)
+        @test nextfloat(-floatmin(VaxFloatG)) == zero(VaxFloatG)
+    end
+
     @testset "Conversion..." begin
         for (vax, ieee) in zip(g8_vax, g8_ieee)
             @test VaxFloatG(vax) == VaxFloatG(ieee)

--- a/test/vaxfloatg.jl
+++ b/test/vaxfloatg.jl
@@ -46,7 +46,7 @@
 
     @testset "Number definitions" begin
         @test floatmax(VaxFloatG) == typemax(VaxFloatG)
-        @test floatmin(VaxFloatG) == typemin(VaxFloatG)
+        @test_broken floatmin(VaxFloatG) == typemin(VaxFloatG)
 
         @test zero(VaxFloatG) == 0
         @test one(VaxFloatG) == 1
@@ -69,7 +69,7 @@
 
         # Numbers smaller than floatmin(VaxFloatG) should underflow
         @test VaxFloatG(prevfloat(convert(Float64, floatmin(VaxFloatG)))) === zero(VaxFloatG)
-        @test VaxFloatG(convert(Float64, floatmin(VaxFloatG))) === floatmin(VaxFloatG)
+        @test_broken VaxFloatG(convert(Float64, floatmin(VaxFloatG))) === floatmin(VaxFloatG)
 
         # Numbers larger than floatmax(VaxFloatG) should error
         @test_throws InexactError VaxFloatG(nextfloat(convert(Float64, floatmax(VaxFloatG))))


### PR DESCRIPTION
# Major new features

- Exact conversion to/from `BigFloat` for `T<:VaxFloat`
  - `VaxFloatF` and `VaxFloatD` has smaller `floatmin` than representable in `Float32` or `Float64`, respectively
  - `VaxFloatG` has larger `floatmax` (larger exponent) than `Float64`
- String macros (eg `vaxf"1.0"`) for F, D, and G Vax floats
- Human readable `show` methods using the new string macros
- Various definitions related to numbers/math:
  - `nextfloat`/`prevfloat`
  - unary `-`
  - <, <=
  - `signbit`
  - `exponent`